### PR TITLE
Further improvements on speed

### DIFF
--- a/R/get_edge_assignment_probs.R
+++ b/R/get_edge_assignment_probs.R
@@ -42,11 +42,12 @@ get_edge_assignment_probs <- function(m, deg.seq, model) {
     if (model == "IEAS") {
         Q.mat <- matrix(0, n, n)
         for (i in 1:n) {
-            for (j in 1:n) {
+            for (j in seq_len(i)) {
                 if (i == j) {
                     Q.mat[i, j] <- deg.seq[i] * (deg.seq[i] - 1) / (2 * m * (2 * m - 1))
                 } else {
                     Q.mat[i, j] <- 2 * deg.seq[i] * (deg.seq[j]) / (2 * m * (2 * m - 1))
+                    Q.mat[j, i] <- Q.mat[i, j]
                 }
             }
         }
@@ -56,11 +57,12 @@ get_edge_assignment_probs <- function(m, deg.seq, model) {
         p.seq <- deg.seq / (2 * m)
         Q.mat <- matrix(0, n, n)
         for (i in 1:n) {
-            for (j in 1:n) {
+            for (j in seq_len(n)) {
                 if (i == j) {
                     Q.mat[i, j] <- p.seq[i]^2
                 } else {
                     Q.mat[i, j] <- 2 * p.seq[i] * p.seq[j]
+                    Q.mat[j, i] <- Q.mat[i, j]
                 }
             }
         }

--- a/R/gof_stats.R
+++ b/R/gof_stats.R
@@ -86,8 +86,8 @@ gof_stats <- function(m, dof, m.seq, prob.mg, Q.seq) {
     round(S, 5) # if you wish to round before finding unique values to make outcome space smaller
   S.uni <- sort(unique(S))
   # probability distribution of the S values
-  prob.tmp <- vector()
-  prob.S <- vector()
+  prob.tmp <- vector("numeric", length(S.uni)*length(S))
+  prob.S <- vector("numeric", length(S.uni))
   for (i in 1:length(S.uni)) {
     for (j in 1:length(S)) {
       if (S.uni[i] == S[j]) {
@@ -95,7 +95,7 @@ gof_stats <- function(m, dof, m.seq, prob.mg, Q.seq) {
       }
     }
     prob.S[i] <- sum(prob.tmp)
-    prob.tmp <- vector()
+    prob.tmp <- vector("numeric", length(S.uni)*length(S))
   }
   cumprob.S <- cumsum(prob.S)
   ExpS <- sum(S.uni * prob.S)
@@ -133,8 +133,8 @@ gof_stats <- function(m, dof, m.seq, prob.mg, Q.seq) {
   # A <- round(A,3) # if you wish to round
   A <- (2 * m * D) / log2(exp(1)) # the asymptotic A statistics
   A.uni <- sort(unique(A))
-  prob.tmp <- vector()
-  prob.A <- vector()
+  prob.tmp <- vector("numeric", length(A.uni)*length(A))
+  prob.A <- vector("numeric", length(A))
   for (i in 1:length(A.uni)) {
     for (j in 1:length(A)) {
       if (A.uni[i] == A[j]) {
@@ -142,7 +142,7 @@ gof_stats <- function(m, dof, m.seq, prob.mg, Q.seq) {
       }
     }
     prob.A[i] <- sum(prob.tmp)
-    prob.tmp <- vector()
+    prob.tmp <- vector("numeric", length(A.uni)*length(A))
   }
   cumprob.A <- cumsum(prob.A)
   ExpA <- sum(A.uni * prob.A)

--- a/R/iea_model.R
+++ b/R/iea_model.R
@@ -136,8 +136,8 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
             Q.mat[i, j] <- p.seq[i]^2
           } else if (i != j) {
             Q.mat[i, j] <- 2*p.seq[i]*p.seq[j]
-          } else {
-            Q.mat[i, j] <- 0
+            # No need to fill the other triangle:
+            # only the lower triangle of the transposed matrix is used
           }
         }
       }
@@ -147,11 +147,13 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
       p.seq <- deg.seq/(2*m)
       Q.mat <- matrix(0, n, n)
       for (i in 1:n) {
-        for (j in 1:n) {
+        for (j in seq_len(i)) {
           if (i == j) {
             Q.mat[i, j] <- p.seq[i]^2
           } else if (i != j) {
             Q.mat[i, j] <- 2*p.seq[i]*p.seq[j]
+            # No need to fill the other triangle:
+            # only the lower triangle of the transposed matrix is used
           } else {
             Q.mat[i, j] <- 0
           }
@@ -218,7 +220,7 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
   for (k in 0:K) {
     covRk <- matrix(0, r, r)
     for (i in 1:r) {
-      for (j in 1:r)
+      for (j in seq_len(i))
         if (i != j) {
           covRk[i, j] <-
             (choose(m, k) * choose(m - k, k)) * (Q.seq[i] ^ k) * (Q.seq[j] ^ k) * (1 -
@@ -227,6 +229,7 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
               choose(m, k) * (Q.seq[i] ^ k) * (1 - Q.seq[i]) ^ (m - k) * (choose(m, k) *
                                                                             (Q.seq[j] ^ k) * (1 - Q.seq[j]) ^ (m - k))
             ))
+          covRk[j, i] <- covRk[i, j]
         } else{
           covRk[i, j] <- (choose(m, k) * (Q.seq[i] ^ k) * (1 - Q.seq[i]) ^ (m - k)) *
             (1 - (choose(m, k) * Q.seq[i] ^ k * ((1 - Q.seq[i]) ^ (m - k))))
@@ -246,12 +249,13 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
 
   # the covariance matrix for local edge multiplicities
   sigma <- matrix(0, r, r)
-  for (i in 1:r) {
-    for (j in 1:r) {
+  for (i in r) {
+    for (j in seq_len(i)) {
       if (i == j) {
         sigma[i, j] <- Q.seq[i] * (1 - Q.seq[j])
       } else {
         sigma[i, j] <- -(Q.seq[i] * Q.seq[j])
+        sigma[j, i] <- sigma[i, j]
       }
     }
   }

--- a/R/iea_model.R
+++ b/R/iea_model.R
@@ -111,11 +111,12 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
       deg.seq <- get_degree_seq(adj, type)
       Q.mat <- matrix(0, n, n)
       for (i in 1:n) {
-        for (j in 1:n) {
+        for (j in seq_len(i)) {
           if (i == j) {
             Q.mat[i, j] <- deg.seq[i] * (deg.seq[i] - 1) / (2 * m * (2 * m - 1))
           } else if (i != j) {
             Q.mat[i, j] <- 2 * deg.seq[i] * (deg.seq[j]) / (2 * m * (2 * m - 1))
+            Q.mat[j, i] <- Q.mat[i, j]
           } else {
             Q.mat[i, j] <- 0
           }
@@ -130,7 +131,7 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
       }
       Q.mat <- matrix(0, n, n)
       for (i in 1:n) {
-        for (j in 1:n) {
+        for (j in seq_len(i)) {
           if (i == j) {
             Q.mat[i, j] <- p.seq[i]^2
           } else if (i != j) {

--- a/R/iea_model.R
+++ b/R/iea_model.R
@@ -177,7 +177,7 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
   Em2 <- m * sum(Q.upmat)
   # alt Em2=m-E(m1)
 
-  cov2 <- vector()
+  cov2 <- vector("numeric", n*n)
   for (i in 1:n) {
     for (j in 1:n) {
       if (i != j) {
@@ -204,19 +204,19 @@ iea_model <- function(adj, type = 'multigraph',  model = 'IEAS', K = 0, apx = FA
   out.M <- round(out.M, 3)
 
   # Rk = frequencies of sites with multiplicities k
-  R <- vector()
+  R <- vector("numeric", K+1)
   for (k in 0:K) {
     R[k + 1] <- sum(m.seq == k)
   }
 
-  ER <- vector()
+  ER <- vector("numeric", K+1)
   for (k in 0:K) {
     ER[k + 1] <- sum(choose(m, k) * Q.seq ^ k * (1 - Q.seq) ^ (m - k))
   }
 
-  VarR <- vector()
-  lower95 <- vector()
-  upper95 <- vector()
+  VarR <- vector("numeric", K+1)
+  lower95 <- vector("numeric", K+1)
+  upper95 <- vector("numeric", K+1)
   for (k in 0:K) {
     covRk <- matrix(0, r, r)
     for (i in 1:r) {

--- a/R/rsm_model.R
+++ b/R/rsm_model.R
@@ -88,11 +88,10 @@ rsm_model <- function(deg.seq) {
     # for each possible edge sequence/multigraph given degree sequence, count number of loops and number of multiple edges using:
     # edge multiplicity sequence = m.seq
     # ordered edge multiplicity sequence = m.seq.star
-    m.seq <- vector()
     m1 <- numeric(nrow(edge.seq))
     m2 <- numeric(nrow(edge.seq))
     m3 <- numeric(nrow(edge.seq))
-    edge.perm <- vector()
+    edge.perm <- vector("numeric", nrow(edge.seq))
     mz <- numeric(nrow(edge.seq))
     tz <- numeric(nrow(edge.seq))
     t <- numeric(nrow(edge.seq))
@@ -155,7 +154,7 @@ rsm_model <- function(deg.seq) {
     Ntot <- sum(tot) # should be equal to: factorial(2*m)/prod(factorial(degvec))
 
     # probability of each multigraph under RSM
-    prob.rsm <- vector()
+    prob.rsm <- vector("numeric", nrow(edge.seq))
     for (i in seq_len(nrow(edge.seq))) {
         tmp <- factorial(m) / prod(factorial(m.seq[i, ]))
         prob.rsm[i] <- ((2^(m2[i])) * tmp) / Ntot


### PR DESCRIPTION
I added some more substitutions to the symmetric matrices.
In the last commit you'll see there are some pre-allocations of vectors: this too makes the code faster (you'll see that I removed a variable `m.seq` that was later overwritten as a matrix instead of a vector).

I hope this helps to make it more practical for larger scale multigraphs. 

This should close #5 (One you merge it Github might automatically close the issue with this line). 